### PR TITLE
feat: 판매 상품 재고 수정 기본 기능

### DIFF
--- a/src/main/java/com/github/supercodingteam1/service/SellService.java
+++ b/src/main/java/com/github/supercodingteam1/service/SellService.java
@@ -9,6 +9,7 @@ import com.github.supercodingteam1.repository.entity.item.ItemRepository;
 import com.github.supercodingteam1.repository.entity.option.Option;
 import com.github.supercodingteam1.repository.entity.option.OptionRepository;
 import com.github.supercodingteam1.web.dto.AddSellItemDTO;
+import com.github.supercodingteam1.web.dto.ModifySalesItemDTO;
 import com.github.supercodingteam1.web.dto.OptionDTO;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +33,11 @@ public class SellService {
 
     private final S3Uploader s3Uploader;
 
+
+    public void updateSellItem(ModifySalesItemDTO modifySalesItemDTO){
+
+
+    }
 
     @Transactional
     public void addSellItem(List<MultipartFile> item_image, AddSellItemDTO addSellItemDTO) {

--- a/src/main/java/com/github/supercodingteam1/service/SellService.java
+++ b/src/main/java/com/github/supercodingteam1/service/SellService.java
@@ -9,8 +9,9 @@ import com.github.supercodingteam1.repository.entity.item.ItemRepository;
 import com.github.supercodingteam1.repository.entity.option.Option;
 import com.github.supercodingteam1.repository.entity.option.OptionRepository;
 import com.github.supercodingteam1.web.dto.AddSellItemDTO;
-import com.github.supercodingteam1.web.dto.ModifySalesItemDTO;
+import com.github.supercodingteam1.web.dto.ModifySalesItemOptionDTO;
 import com.github.supercodingteam1.web.dto.OptionDTO;
+import com.github.supercodingteam1.web.exceptions.NotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -34,10 +35,23 @@ public class SellService {
     private final S3Uploader s3Uploader;
 
 
-    public void updateSellItem(ModifySalesItemDTO modifySalesItemDTO){
+    public void updateSellItem(List<ModifySalesItemOptionDTO> modifySalesItemOptionDTOList) {
+        // 각 옵션에 대해 업데이트
+        for (ModifySalesItemOptionDTO dto : modifySalesItemOptionDTOList) {
+            // 옵션 ID에 해당하는 옵션을 조회
+            Option option = optionRepository.findById(dto.getOptionId())
+                    .orElseThrow(() -> new NotFoundException("Option not found with id: " + dto.getOptionId()));
 
+            // 재고(stock)를 업데이트
+            option.setStock(dto.getNewStock());
 
+            // 변경된 값을 저장
+            optionRepository.save(option);
+
+            log.info("Option {}의 재고가 {}로 업데이트되었습니다.", dto.getOptionId(), dto.getNewStock());
+        }
     }
+
 
     @Transactional
     public void addSellItem(List<MultipartFile> item_image, AddSellItemDTO addSellItemDTO) {

--- a/src/main/java/com/github/supercodingteam1/service/SellService.java
+++ b/src/main/java/com/github/supercodingteam1/service/SellService.java
@@ -35,6 +35,7 @@ public class SellService {
     private final S3Uploader s3Uploader;
 
 
+    @Transactional
     public void updateSellItem(List<ModifySalesItemOptionDTO> modifySalesItemOptionDTOList) {
         // 각 옵션에 대해 업데이트
         for (ModifySalesItemOptionDTO dto : modifySalesItemOptionDTOList) {

--- a/src/main/java/com/github/supercodingteam1/web/controller/SalesController.java
+++ b/src/main/java/com/github/supercodingteam1/web/controller/SalesController.java
@@ -2,6 +2,7 @@ package com.github.supercodingteam1.web.controller;
 
 import com.github.supercodingteam1.service.SellService;
 import com.github.supercodingteam1.web.dto.AddSellItemDTO;
+import com.github.supercodingteam1.web.dto.ModifySalesItemDTO;
 import com.github.supercodingteam1.web.dto.ResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -40,6 +41,24 @@ public class SalesController {
         return ResponseDTO.builder()
                 .status(200)
                 .message("판매물품을 성공적으로 등록하였습니다").
+                build();
+    }
+
+    @Operation(summary = "판매 물품 옵션 재고 수정")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공적으로 수정했습니다."),
+            @ApiResponse(responseCode = "403", description = "권한이 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseDTO updateSellItem(@Parameter(description = "옵션 재고 수정", required = true) @RequestBody ModifySalesItemDTO modifySalesItemDTO){
+
+        log.info("updateSellItem 메소드 호출 {}", modifySalesItemDTO);
+        sellService.updateSellItem(modifySalesItemDTO);
+
+        return ResponseDTO.builder()
+                .status(200)
+                .message("물품의 옵션을 성공적으로 수정하였습니다").
                 build();
     }
 }

--- a/src/main/java/com/github/supercodingteam1/web/controller/SalesController.java
+++ b/src/main/java/com/github/supercodingteam1/web/controller/SalesController.java
@@ -2,13 +2,12 @@ package com.github.supercodingteam1.web.controller;
 
 import com.github.supercodingteam1.service.SellService;
 import com.github.supercodingteam1.web.dto.AddSellItemDTO;
-import com.github.supercodingteam1.web.dto.ModifySalesItemDTO;
+import com.github.supercodingteam1.web.dto.ModifySalesItemOptionDTO;
 import com.github.supercodingteam1.web.dto.ResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,14 +50,14 @@ public class SalesController {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseDTO updateSellItem(@Parameter(description = "옵션 재고 수정", required = true) @RequestBody ModifySalesItemDTO modifySalesItemDTO){
+    public ResponseDTO updateSellItem(@Parameter(description = "옵션 재고 수정", required = true) @RequestBody List<ModifySalesItemOptionDTO> modifySalesItemOptionDTO){
 
-        log.info("updateSellItem 메소드 호출 {}", modifySalesItemDTO);
-        sellService.updateSellItem(modifySalesItemDTO);
+        log.info("updateSellItem 메소드 호출 {}", modifySalesItemOptionDTO);
+        sellService.updateSellItem(modifySalesItemOptionDTO);
 
         return ResponseDTO.builder()
                 .status(200)
-                .message("물품의 옵션을 성공적으로 수정하였습니다").
+                .message("상품 옵션의 재고를 성공적으로 수정하였습니다").
                 build();
     }
 }

--- a/src/main/java/com/github/supercodingteam1/web/dto/ModifySalesItemDTO.java
+++ b/src/main/java/com/github/supercodingteam1/web/dto/ModifySalesItemDTO.java
@@ -1,0 +1,15 @@
+package com.github.supercodingteam1.web.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ModifySalesItemDTO {
+    private Integer optionId;
+    private Integer newStock;
+}

--- a/src/main/java/com/github/supercodingteam1/web/dto/ModifySalesItemOptionDTO.java
+++ b/src/main/java/com/github/supercodingteam1/web/dto/ModifySalesItemOptionDTO.java
@@ -2,14 +2,12 @@ package com.github.supercodingteam1.web.dto;
 
 import lombok.*;
 
-import java.util.List;
-
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class ModifySalesItemDTO {
+public class ModifySalesItemOptionDTO {
     private Integer optionId;
     private Integer newStock;
 }


### PR DESCRIPTION
재고 수정 기본 기능을 구현했습니다.
재고의 원자성 측면에서 여러가지로 생각하고 리팩토링할 예정입니다.
예를 들어 장바구니에 있는 상품의 재고가 품절이 되면 어떻게 처리할 것인가, 
구매 로직의 어느 단계에서 재고를 변경하고 예외를 던져야 할까, 같은 문제가 많아보입니다.