### PR TITLE
Feat : 재고 수정 로직 구현

### DIFF
--- a/src/main/java/com/github/supercodingteam1/repository/entity/option/OptionRepository.java
+++ b/src/main/java/com/github/supercodingteam1/repository/entity/option/OptionRepository.java
@@ -2,12 +2,23 @@ package com.github.supercodingteam1.repository.entity.option;
 
 
 import com.github.supercodingteam1.repository.entity.item.Item;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface OptionRepository extends JpaRepository<Option,Integer> {
     public List<Option> findAllByItem(Item item);
+
+    // 동시성 문제 해결을 위한 비관적 락 사용
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT o FROM Option o WHERE o.optionId = :optionId")
+    Optional<Option> findByOptionId(@Param("optionId") Integer optionId);
+
 }

--- a/src/main/java/com/github/supercodingteam1/web/controller/SalesController.java
+++ b/src/main/java/com/github/supercodingteam1/web/controller/SalesController.java
@@ -95,14 +95,20 @@ public class SalesController {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @PutMapping
-    public ResponseDTO updateSellItem(@Parameter(description = "옵션 재고 수정", required = true) @RequestBody List<ModifySalesItemOptionDTO> modifySalesItemOptionDTO){
+    public ResponseEntity<?> updateSellItem(@Parameter(description = "옵션 재고 수정", required = true) @RequestBody List<ModifySalesItemOptionDTO> modifySalesItemOptionDTO, @AuthenticationPrincipal CustomUserDetails customUserDetails){
 
         log.info("updateSellItem 메소드 호출 {}", modifySalesItemOptionDTO);
-        sellService.updateSellItem(modifySalesItemOptionDTO);
 
-        return ResponseDTO.builder()
-                .status(200)
-                .message("상품 옵션의 재고를 성공적으로 수정하였습니다").
-                build();
+        try {
+            sellService.updateSellItem(modifySalesItemOptionDTO,customUserDetails);
+            return ResponseEntity.ok().body(ResponseDTO.builder()
+                    .status(200)
+                    .message("상품 옵션의 재고를 성공적으로 수정하였습니다").
+                    build());
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ResponseDTO.builder()
+                    .status(404).message(e.getMessage()).build());
+        }
+
     }
 }

--- a/src/main/java/com/github/supercodingteam1/web/controller/SalesController.java
+++ b/src/main/java/com/github/supercodingteam1/web/controller/SalesController.java
@@ -7,10 +7,12 @@ import com.github.supercodingteam1.web.dto.GetAllSalesItemDTO;
 import com.github.supercodingteam1.web.dto.ModifySalesItemOptionDTO;
 import com.github.supercodingteam1.web.dto.ResponseDTO;
 import com.github.supercodingteam1.web.exceptions.NotFoundException;
+import com.github.supercodingteam1.web.exceptions.UnauthorizedAccessException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,20 +97,31 @@ public class SalesController {
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
     @PutMapping
-    public ResponseEntity<?> updateSellItem(@Parameter(description = "옵션 재고 수정", required = true) @RequestBody List<ModifySalesItemOptionDTO> modifySalesItemOptionDTO, @AuthenticationPrincipal CustomUserDetails customUserDetails){
-
-        log.info("updateSellItem 메소드 호출 {}", modifySalesItemOptionDTO);
+    public ResponseEntity<?> updateSellItem(
+            @Valid @RequestBody List<ModifySalesItemOptionDTO> modifySalesItemOptionDTOList,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         try {
-            sellService.updateSellItem(modifySalesItemOptionDTO,customUserDetails);
+            sellService.updateSellItem(modifySalesItemOptionDTOList, customUserDetails);
             return ResponseEntity.ok().body(ResponseDTO.builder()
                     .status(200)
-                    .message("상품 옵션의 재고를 성공적으로 수정하였습니다").
-                    build());
-        }catch (Exception e){
+                    .message("상품 옵션의 재고를 성공적으로 수정하였습니다.")
+                    .build());
+        } catch (UnauthorizedAccessException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ResponseDTO.builder()
+                    .status(403)
+                    .message(e.getMessage())
+                    .build());
+        } catch (NotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ResponseDTO.builder()
-                    .status(404).message(e.getMessage()).build());
+                    .status(404)
+                    .message(e.getMessage())
+                    .build());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ResponseDTO.builder()
+                    .status(500)
+                    .message("서버 오류가 발생했습니다.")
+                    .build());
         }
-
     }
 }

--- a/src/main/java/com/github/supercodingteam1/web/dto/ModifySalesItemOptionDTO.java
+++ b/src/main/java/com/github/supercodingteam1/web/dto/ModifySalesItemOptionDTO.java
@@ -1,5 +1,8 @@
 package com.github.supercodingteam1.web.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
@@ -7,7 +10,11 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Valid
 public class ModifySalesItemOptionDTO {
+    @NotNull(message = "옵션 ID는 필수입니다.")
     private Integer optionId;
+
+    @Min(value = 0, message = "재고는 0 이상이어야 합니다.")
     private Integer newStock;
 }

--- a/src/main/java/com/github/supercodingteam1/web/exceptions/InvalidStockException.java
+++ b/src/main/java/com/github/supercodingteam1/web/exceptions/InvalidStockException.java
@@ -1,0 +1,7 @@
+package com.github.supercodingteam1.web.exceptions;
+
+public class InvalidStockException extends RuntimeException {
+    public InvalidStockException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/supercodingteam1/web/exceptions/OptionNotFoundException.java
+++ b/src/main/java/com/github/supercodingteam1/web/exceptions/OptionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.github.supercodingteam1.web.exceptions;
+
+public class OptionNotFoundException extends RuntimeException {
+    public OptionNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/supercodingteam1/web/exceptions/UnauthorizedAccessException.java
+++ b/src/main/java/com/github/supercodingteam1/web/exceptions/UnauthorizedAccessException.java
@@ -1,0 +1,7 @@
+package com.github.supercodingteam1.web.exceptions;
+
+public class UnauthorizedAccessException extends RuntimeException {
+    public UnauthorizedAccessException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
option_id와 new_stock을 필드로 갖는 ModifySalesItemOptionDTO을 list로 받아서 재고 수정하는 service로직 구현했습니다. 
-재고 수정 과정에서 재고 변경을 막기 위해 데이터베이스 수준에서 해당 데이터를 수정하는 동안 다른 트랜잭션이 접근하지 못하게 하는 비관적 락을 리포지토리 어노테이션 @Lock(LockModeType.PESSIMISTIC_WRITE)을 통해 구현.
-잘못된 값 입력을 막기 위해 dto에 유효성 검사 @NotNull, @Min 어노테이션 적용